### PR TITLE
Update NiwakiLauncher version to 1.1.8

### DIFF
--- a/NiwakiLauncher/NiwakiLauncher.csproj
+++ b/NiwakiLauncher/NiwakiLauncher.csproj
@@ -7,7 +7,7 @@
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <ApplicationIcon>Assets\niwaki.ico</ApplicationIcon>
-        <Version>1.1.7-debug</Version>
+        <Version>1.1.8</Version>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
       <DebugType>embedded</DebugType>


### PR DESCRIPTION
The version number for the NiwakiLauncher has been increased from 1.1.7-debug to 1.1.8. This update reflects the latest resolved issues and feature additions to the software.